### PR TITLE
Add parameter to store cardano-wallet db

### DIFF
--- a/mainnet/scripts/wallet.sh
+++ b/mainnet/scripts/wallet.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cardano-wallet serve --mainnet --node-socket ../apps/cardano-node/node.sock
+cardano-wallet serve --mainnet --node-socket ../apps/cardano-node/node.sock --database ../data/wallet

--- a/testnet-preprod/scripts/wallet.sh
+++ b/testnet-preprod/scripts/wallet.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cardano-wallet serve --testnet ../apps/cardano-node/byron-genesis.json --node-socket ../apps/cardano-node/node.sock
+cardano-wallet serve --testnet ../apps/cardano-node/byron-genesis.json --node-socket ../apps/cardano-node/node.sock --database ../data/wallet

--- a/testnet-preview/scripts/wallet.sh
+++ b/testnet-preview/scripts/wallet.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cardano-wallet serve --testnet ../apps/cardano-node/byron-genesis.json --node-socket ../apps/cardano-node/node.sock
+cardano-wallet serve --testnet ../apps/cardano-node/byron-genesis.json --node-socket ../apps/cardano-node/node.sock --database ../data/wallet


### PR DESCRIPTION
Without this parameter, whenever the cardano-wallet is restarted, a complete synchronization is done from scratch. Which on mainnet is a substantial problem, takes around 3 hours to complete.

Change tested and validated.

Documentation: https://cardano-foundation.github.io/cardano-wallet/user/common-use-cases/start-wallet-server.html